### PR TITLE
fix(api): warn if try to send email withn old app

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api_mano",
   "version": "1.79.4",
-  "mobileAppVersion": "1.6.0",
+  "mobileAppVersion": "1.7.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/api/src/controllers/event.js
+++ b/api/src/controllers/event.js
@@ -16,6 +16,28 @@ router.post(
       return res.status(200).send({ ok: true, newFeatures: [newFeatures["new-defis"], newFeatures["new-articles"]] });
     }
 
+    const sendNPSEvent = body.event?.category === "NPS";
+    const exportDataEvent = body.event?.category === "EXPORT";
+    if (appversion < 99 && (exportDataEvent || sendNPSEvent)) {
+      return res.status(200).send({
+        ok: true,
+        sendInApp: [
+          "L'envoi d'email n'est plus disponible sur cette version d'application",
+          "Mettez à jour votre application !",
+          [
+            {
+              text: "Mettre à jour",
+              link:
+                appdevice === "ios"
+                  ? "https://apps.apple.com/us/app/oz-ensemble/id1498190343?ls=1"
+                  : "https://play.google.com/store/apps/details?id=com.addicto",
+            },
+          ],
+          { cancelable: true },
+        ],
+      });
+    }
+
     return res.status(200).send({ ok: true });
   })
 );


### PR DESCRIPTION
ce que je veux tester: que l'alerte s'affiche au bon endroit (export des données et NPS)

est-ce que tu peux tester ?
pour ce faire, tu peux changer 99 en 100 (pour pas avoir à rebuild), et aller sur les pages Export et NPS et vérifier que t'as bien l'alerte qui s'affiche