### PR TITLE
fix(docker): set node_modules owner as node for npx

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16-alpine3.16
 
 WORKDIR /app
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,11 +4,11 @@ WORKDIR /app
 
 RUN chown node:node /app
 
+USER 1000
+
 COPY . .
 
 RUN yarn --production --frozen-lockfile
-
-USER node
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
mets le droits en écriture au user "node" sur le dossier "node_modules"

le `npx prisma migrate` a besoin d'écrire dans ce dossier au démarrage du container