### PR TITLE
fix: OZENSEMBLE-N0

### DIFF
--- a/expo/src/services/deepLink.js
+++ b/expo/src/services/deepLink.js
@@ -65,7 +65,35 @@ export const deepLinkingConfig = {
 
     // // Handle URL from expo push notifications
     const response = await Notifications.getLastNotificationResponseAsync();
-    return response?.notification.request.content.data.url;
+    console.log("NotificationService getInitialURL:", JSON.stringify(response, null, 2));
+    console.log("URL is ", response?.notification?.request?.content?.data?.url);
+    /* NOTE
+    as of 2024-08-08 there is a bug in expo-notifications -> https://github.com/expo/expo/issues/28656
+    here is the log received from the console.log above:
+    (NOBRIDGE) LOG  NotificationService getInitialURL: {
+      "actionIdentifier": "expo.modules.notifications.actions.DEFAULT",
+      "notification": {
+        "date": 1723106331352,
+        "request": {
+          "identifier": "0:172sd;lmsdf%asdlknsalkmfaslkmdfa",
+          "content": {
+            "body": "N'oubliez pas de remplir votre agenda Oz",
+            "dataString": null,
+            "title": "C'est l'heure de votre suivi !"
+          },
+          "trigger": {
+            "type": "push",
+            "channelId": null
+          }
+        }
+      }
+    }
+    (NOBRIDGE) LOG  URL is  undefined
+
+    let's see if the nmapping is still correct when the bug is fixed
+    */
+
+    return response?.notification?.request?.content?.data?.url;
   },
   subscribe(listener) {
     // Listen to incoming links from deep linking
@@ -74,17 +102,109 @@ export const deepLinkingConfig = {
     });
 
     // Listen to expo push notifications
-    const notificationsSubscription = Notifications.addNotificationResponseReceivedListener(
-      (response) => {
-        const url = response.notification.request.content.data.link;
+    const notificationsSubscription = Notifications.addNotificationResponseReceivedListener((response) => {
+      console.log("NotificationService notificationsSubscription:", JSON.stringify(response, null, 2));
+      const url = response?.notification?.request?.content?.data?.link;
+      // Any custom logic to see whether the URL needs to be handled
+      //...
+      /* NOTE
+    as of 2024-08-08 there is a bug in expo-notifications -> https://github.com/expo/expo/issues/28656
+    here is the log received from the console.log above, when received in background:
 
-        // Any custom logic to see whether the URL needs to be handled
-        //...
-
-        // Let React Navigation handle the URL
-        if (url) listener(url);
+     (NOBRIDGE) LOG  NotificationService notificationsSubscription: {
+        "notification": {
+          "request": {
+            "trigger": {
+              "channelId": null,
+              "type": "push"
+            },
+            "content": {
+              "title": "C'est l'heure de votre suivi !",
+              "dataString": null,
+              "body": "N'oubliez pas de remplir votre agenda Oz"
+            },
+            "identifier": "0:172sd;lmsdf%asdlknsalkmfaslkmdfa"
+          },
+          "date": 1723106501392
+        },
+        "actionIdentifier": "expo.modules.notifications.actions.DEFAULT"
       }
-    );
+
+      and when receive in foreground
+
+      (NOBRIDGE) LOG  NotificationService notificationsSubscription: {
+        "notification": {
+          "request": {
+            "trigger": {
+              "remoteMessage": {
+                "originalPriority": 1,
+                "sentTime": 1723106569980,
+                "notification": {
+                  "usesDefaultVibrateSettings": false,
+                  "color": null,
+                  "channelId": null,
+                  "visibility": null,
+                  "sound": null,
+                  "tag": null,
+                  "bodyLocalizationArgs": null,
+                  "imageUrl": null,
+                  "title": "C'est l'heure de votre suivi !",
+                  "ticker": null,
+                  "eventTime": null,
+                  "body": "N'oubliez pas de remplir votre agenda Oz",
+                  "titleLocalizationKey": null,
+                  "notificationPriority": null,
+                  "icon": null,
+                  "usesDefaultLightSettings": false,
+                  "sticky": false,
+                  "link": null,
+                  "titleLocalizationArgs": null,
+                  "bodyLocalizationKey": null,
+                  "usesDefaultSound": false,
+                  "clickAction": null,
+                  "localOnly": false,
+                  "lightSettings": null,
+                  "notificationCount": null
+                },
+                "data": {
+                  "message": "N'oubliez pas de remplir votre agenda Oz",
+                  "title": "C'est l'heure de votre suivi !",
+                  "link": "oz://ADD_DRINK"
+                },
+                "to": null,
+                "ttl": 2419200,
+                "collapseKey": "com.addicto",
+                "messageType": null,
+                "priority": 1,
+                "from": "90509851991",
+                "messageId": "0:blablabla"
+              },
+              "channelId": null,
+              "type": "push"
+            },
+            "content": {
+              "title": "C'est l'heure de votre suivi !",
+              "badge": null,
+              "autoDismiss": true,
+              "data": null,
+              "body": "N'oubliez pas de remplir votre agenda Oz",
+              "sound": "default",
+              "sticky": false,
+              "subtitle": null
+            },
+            "identifier": "0:blablabla"
+          },
+          "date": 1723106569980
+        },
+        "actionIdentifier": "expo.modules.notifications.actions.DEFAULT"
+      }
+
+    let's see if the nmapping is still correct when the bug is fixed
+    */
+
+      // Let React Navigation handle the URL
+      if (url) listener(url);
+    });
 
     return () => {
       // Clean up the event listeners

--- a/expo/src/services/deepLink.js
+++ b/expo/src/services/deepLink.js
@@ -58,13 +58,15 @@ export const deepLinkingConfig = {
   async getInitialURL() {
     // Check if app was opened from a deep link
     // FIXME: this methods makes the app crash
-    const url = await Linking.getInitialURL();
+    let url = await Linking.getInitialURL();
     if (url != null) {
       return url;
     }
 
     // // Handle URL from expo push notifications
     const response = await Notifications.getLastNotificationResponseAsync();
+    url =
+      response?.notification?.request?.content?.data?.url ?? response?.notification?.request?.trigger?.payload?.link;
     console.log("NotificationService getInitialURL:", JSON.stringify(response, null, 2));
     console.log("URL is ", response?.notification?.request?.content?.data?.url);
     /* NOTE
@@ -92,8 +94,7 @@ export const deepLinkingConfig = {
 
     let's see if the nmapping is still correct when the bug is fixed
     */
-
-    return response?.notification?.request?.content?.data?.url;
+    return url;
   },
   subscribe(listener) {
     // Listen to incoming links from deep linking
@@ -104,7 +105,9 @@ export const deepLinkingConfig = {
     // Listen to expo push notifications
     const notificationsSubscription = Notifications.addNotificationResponseReceivedListener((response) => {
       console.log("NotificationService notificationsSubscription:", JSON.stringify(response, null, 2));
-      const url = response?.notification?.request?.content?.data?.link;
+      const url =
+        response?.notification?.request?.content?.data?.link ?? response?.notification?.request?.trigger?.payload?.link;
+      console.log("URL noitif sub is ", url);
       // Any custom logic to see whether the URL needs to be handled
       //...
       /* NOTE


### PR DESCRIPTION
on voit que grâce aux logs on reçoit

```
 NotificationService notificationsSubscription: {
  "notification": {
    "request": {
      "trigger": {
        "channelId": null,
        "type": "push"
      },
      "content": {
        "title": "C'est l'heure de votre suivi !",
        "dataString": null,
        "body": "N'oubliez pas de remplir votre agenda Oz"
      },
      "identifier": "0:1723103761373654%0775fdc90775fdc9"
    },
    "date": 1723103761365
  },
  "actionIdentifier": "expo.modules.notifications.actions.DEFAULT"
}
```

donc avec le fix proposé, tout va bien, non ?